### PR TITLE
[Sikkerhet] Oppretter sikkerhetsmappa med beskrivelse.yaml og legger til Security Champion i CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.sikkerhet/ @DanielBerge

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,0 +1,2 @@
+version: 1.0
+organisasjon: Eiendom


### PR DESCRIPTION
## Kort forklart
Denne PRen oppretter filen `.sikkerhet/beskrivelse.yaml`, og `.github\CODEOWNERS` dersom `CODEOWNERS` ikke allerede finnes

I `CODEOWNERS` legges det til linjen `/.sikkerhet/ @DanielBerge`, der `DanielBerge` er GitHub-brukernavnet til den som skal være teamets kontaktperson om sikkerhet ([Security Champion](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732332108/Security+Champion)).

I `/.sikkerhet/beskrivelse.yaml` ligger linjen `organisasjon: Eiendom`, som sier hvilken del av organisasjonen kodebasen tilhører.

## Litt lenger forklart (hvorfor gjør vi dette?)
Det er beskrevet [her i Sikkehertshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet).