### PR TITLE
[Sikkerhet] Oppdaterer catalog-info.yaml med komponent

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "dokumentbestilling-systembeskrivelse"
+  tags:
+  - "public"
+  links:
+  - url: "https://github.com/kartverket/dokumentbestilling-systembeskrivelse"
+    title: "dokumentbestilling-systembeskrivelse på GitHub"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "Eiet"
+  system: "Dokumentbestilling"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.