### PR TITLE
[Sikkerhet] Oppdaterer catalog-info.yaml med komponent

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,11 +5,35 @@ metadata:
   name: "dokumentbestilling-systembeskrivelse"
   tags:
   - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "eiet"
+  system: "dokumentbestilling"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_dokumentbestilling-systembeskrivelse"
+  title: "Security Champion dokumentbestilling-systembeskrivelse"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "DanielBerge"
+  children:
+  - "resource:dokumentbestilling-systembeskrivelse"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "dokumentbestilling-systembeskrivelse"
   links:
   - url: "https://github.com/kartverket/dokumentbestilling-systembeskrivelse"
     title: "dokumentbestilling-systembeskrivelse på GitHub"
 spec:
-  type: "documentation"
-  lifecycle: "production"
-  owner: "Eiet"
-  system: "Dokumentbestilling"
+  type: "repo"
+  owner: "security_champion_dokumentbestilling-systembeskrivelse"
+  system: "dokumentbestilling"
+  dependencyOf:
+  - "component:dokumentbestilling-systembeskrivelse"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.