### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @DanielBerge
+/.security/ @DanielBerge

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 2.0
 organization: Eiendom
 product: Dokumentbestilling
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,30 +10,3 @@ spec:
   lifecycle: "production"
   owner: "eiet"
   system: "dokumentbestilling"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_dokumentbestilling-systembeskrivelse"
-  title: "Security Champion dokumentbestilling-systembeskrivelse"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "DanielBerge"
-  children:
-  - "resource:dokumentbestilling-systembeskrivelse"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "dokumentbestilling-systembeskrivelse"
-  links:
-  - url: "https://github.com/kartverket/dokumentbestilling-systembeskrivelse"
-    title: "dokumentbestilling-systembeskrivelse på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_dokumentbestilling-systembeskrivelse"
-  system: "dokumentbestilling"
-  dependencyOf:
-  - "component:dokumentbestilling-systembeskrivelse"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml